### PR TITLE
Add fab for scrolling up as a temp fix for #84

### DIFF
--- a/app/src/main/java/dev/sanskar/transactions/ui/home/HomeFragment.kt
+++ b/app/src/main/java/dev/sanskar/transactions/ui/home/HomeFragment.kt
@@ -14,6 +14,7 @@ import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.play.core.review.ReviewManagerFactory
 import dagger.hilt.android.AndroidEntryPoint
 import dev.sanskar.transactions.*
+import dev.sanskar.transactions.show
 import dev.sanskar.transactions.data.FilterByMediumChoices
 import dev.sanskar.transactions.data.FilterByTypeChoices
 import dev.sanskar.transactions.data.SortByChoices
@@ -73,6 +74,21 @@ class HomeFragment : Fragment() {
         binding.listTransactions.adapter = adapter
         setupRecyclerViewSwipe()
         onboard()
+
+        binding.listTransactions.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                super.onScrolled(recyclerView, dx, dy)
+                if (dy > 0) {
+                    binding.fabScrollToTop.apply {
+                        setOnClickListener { recyclerView.smoothScrollToPosition(0) }
+                        show()
+                    }
+                }
+                if (! binding.listTransactions.canScrollVertically(-1)) {
+                    binding.fabScrollToTop.hide()
+                }
+            }
+        })
 
         binding.fabAddTransaction.setOnClickListener {
             findNavController().navigate(R.id.action_homeFragment_to_addTransactionFragment)

--- a/app/src/main/res/drawable/ic_baseline_arrow_upward_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_arrow_upward_24.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -13,10 +13,26 @@
         android:layout_marginEnd="16dp"
         android:layout_marginBottom="16dp"
         android:clickable="true"
+        android:focusable="true"
         android:contentDescription="FAB to add a transaction"
         android:src="@drawable/ic_baseline_add_circle_24"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_scroll_to_top"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="16dp"
+        android:clickable="true"
+        android:contentDescription="FAB to scroll to top"
+        android:focusable="true"
+        android:src="@drawable/ic_baseline_arrow_upward_24"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/textView_cash_balance"


### PR DESCRIPTION
Since there's no concrete mechanism to know if a specific filter has been applied, it's nearly impossible to scroll automatically to the top without breaking existing add/delete behavior.

This doesn't completely fix #84, but it'll have to do for now.

Resolves #84 